### PR TITLE
Only call pull in fetch feedback

### DIFF
--- a/grader_labextension/grader_labextension/handlers/grading.py
+++ b/grader_labextension/grader_labextension/handlers/grading.py
@@ -250,7 +250,5 @@ class PullFeedbackHandler(ExtensionBaseHandler):
         if not git_service.is_git():
             git_service.init()
         git_service.set_remote("feedback", sub_id=sub_id)
-        # we just need to fetch --all and switch branch (otherwise for pull we get "fatal: refusing to merge unrelated histories")
-        git_service.switch_branch(branch=f"feedback_{submission['commit_hash']}")
-        git_service.pull("feedback", branch=f"feedback_{submission['commit_hash']}", force=True)
+        git_service.pull("feedback", branch=f"feedback_{submission['commit_hash']}", force=False)
         self.write("Pulled Feedback")

--- a/grader_service/grader_service/handlers/git/server.py
+++ b/grader_service/grader_service/handlers/git/server.py
@@ -204,7 +204,7 @@ class GitBaseHandler(GraderBaseHandler):
         if extensions is None:
             req_handler_conf = RequestHandlerConfig.instance()
             extensions = req_handler_conf.git_allowed_file_extensions
-        elif len(extensions) > 0:
+        if len(extensions) > 0:
             allow_patterns = ["\\." + s.strip(".").replace(".", "\\.") for s in extensions]  # noqa E501
             pattern = "|".join(allow_patterns)
         return pattern


### PR DESCRIPTION
This solves the bug that some users had where fetch --all did not work. One disadvantage with this patch is that when a user deletes their files, pulling again does not reset the state.

Fix bug in git server where incorrect conditional led to incorrect file allow pattern