### PR TITLE
Fix Development Environment

### DIFF
--- a/docs/source/installation/installation_from_source.md
+++ b/docs/source/installation/installation_from_source.md
@@ -34,11 +34,11 @@ Running this command will make sure that all dependencies from `pyproject.toml` 
 
 ### Grader Labextension
 
-To locally install Grader Labextension, make sure to clone [Grader Labextension project](https://github.com/TU-Wien-dataLAB/Grader-Labextension) or download the corresponding [zip file](https://github.com/TU-Wien-dataLAB/Grader-Labextension/archive/refs/heads/main.zip).
+To locally install Grader Labextension, make sure to clone [Grader Labextension project](https://github.com/TU-Wien-dataLAB/grader-labextension) or download the corresponding [zip file](https://github.com/TU-Wien-dataLAB/Grader-Labextension/archive/refs/heads/main.zip).
 
 Grader Labextension is composed of a Python package named `grader_labextension` for the server extension and an NPM package `grader-labextension` for the frontend extensio.
 
-To install the extension in development mode, navigate to your local `Grader_Labextension` directory and run:
+To install the extension in development mode, navigate to your local `grader-labextension` directory and run:
 
 ```bash
 pip install -e .
@@ -76,6 +76,7 @@ Keep in mind that `jlpm watch` continues running until you stop it and can consu
 ## Installation Scripts
 
 Alternatively you can use installation scripts which you can find in `examples/dev_environment` directory. This directory provides you with local development environment and serves as a guide for more complex setups. The bash scripts have to be run in the `dev_environment` directory.
+Ensure that you cloned the [Grader Labextension project](https://github.com/TU-Wien-dataLAB/grader-labextension) and it is located in the same directory as the grader service repository.
 
 The `dev_enviroment` directory contains following files:
 

--- a/examples/dev_environment/clean.sh
+++ b/examples/dev_environment/clean.sh
@@ -4,8 +4,6 @@
 rm -rf ./home_dir
 rm -rf ./service_dir
 
-rm ./grader.db
-
-rm ./jupyterhub-proxy.pid
-rm ./jupyterhub.sqlite
-rm ./jupyterhub_cookie_secret
+rm -f ./jupyterhub-proxy.pid
+rm -f ./jupyterhub.sqlite
+rm -f ./jupyterhub_cookie_secret

--- a/examples/dev_environment/grader_service_config.py
+++ b/examples/dev_environment/grader_service_config.py
@@ -17,7 +17,7 @@ print("### loading service config")
 
 c.GraderService.service_host = "127.0.0.1"
 # existing directory to use as the base directory for the grader service
-service_dir = os.path.expanduser("~/grader_service_dir")
+service_dir = os.path.join(os.getcwd(), "service_dir")
 c.GraderService.grader_service_dir = service_dir
 
 c.RequestHandlerConfig.autograde_executor_class = LocalAutogradeExecutor

--- a/examples/dev_environment/install.sh
+++ b/examples/dev_environment/install.sh
@@ -1,19 +1,21 @@
 #!/bin/bash
 
+DEV_ENV_DIR=$PWD
+
 echo "Creating virtual environment..."
 python -m venv venv
 source ./venv/bin/activate
 which python
 
 python -m pip install --upgrade pip
-pip install jupyterhub jupyterlab
+pip install jupyterhub jupyterlab oauthenticator
 
 echo "Installing grader_service..."
 cd ../../
 pip install -e .
 
 echo "Installing grader_labextension..."
-cd ../Grader-Labextension
+cd ../grader-labextension
 pip install -e .
 
 jupyter labextension develop . --overwrite
@@ -25,6 +27,8 @@ jupyter server extension list
 jupyter labextension list
 
 # home directory for users
+cd $DEV_ENV_DIR
+
 mkdir -p ./home_dir
 
 mkdir -p ./service_dir

--- a/examples/dev_environment/jupyterhub_config.py
+++ b/examples/dev_environment/jupyterhub_config.py
@@ -1,4 +1,5 @@
 from jupyterhub import orm
+import os
 
 ## generic
 c.JupyterHub.admin_access = True
@@ -45,7 +46,7 @@ c.Authenticator.admin_users = {"admin"}
 
 ## spawner
 c.JupyterHub.spawner_class = 'jupyterhub.spawner.SimpleLocalProcessSpawner'
-c.SimpleLocalProcessSpawner.home_dir_template = '/tmp/lab_dir/{username}'
+c.SimpleLocalProcessSpawner.home_dir_template = os.path.join(os.getcwd(), "home_dir", "{username}")
 
 ## simple setup
 c.JupyterHub.ip = '127.0.0.1'

--- a/examples/dev_environment/run_hub.sh
+++ b/examples/dev_environment/run_hub.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
 source ./venv/bin/activate
+
+export JUPYTERHUB_CRYPT_KEY=$(openssl rand -hex 32)
 jupyterhub -f ./jupyterhub_config.py


### PR DESCRIPTION
This PR fixes and adjusts the local development environment to run the grader service and JupyteHub:

- Refer to the created directories `./home_dir` and `./service_dir` in grader and JupyterHub config
- Update directory name of the cloned lab extension repository
- Install missing [oauthenticator](https://github.com/jupyterhub/oauthenticator)
- Create [`JUPYTERHUB_CRYPT_KEY`](https://jupyterhub.readthedocs.io/en/latest/reference/authenticators.html#authentication-state)
- Mention to clone the lab extension repository

After applying these changes, it should be possible to run the grader service and JupyterHub without further adjustments.