### PR TITLE
272 fix: Student notebooks are ignored when the whitelist contains "*.ipynb"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ jupyterhub.sqlite*
 /examples/dev_environment/service_dir/**/*
 /examples/dev_environment/venv
 /service_dir
+/home_dir
 
 /examples/docker_compose/data
 /examples/docker_compose/data-hub

--- a/grader_service/autograding/local_grader.py
+++ b/grader_service/autograding/local_grader.py
@@ -317,7 +317,9 @@ class LocalAutogradeExecutor(LoggingConfigurable):
         else:
             group = self.session.query(Group).get((self.submission.username, lecture.id))
             if group is None:
-                raise ValueError()
+                raise ValueError(
+                    f"Group with username {self.submission.username} and lecture id {lecture.id} not found"
+                )
             repo_name = group.name
 
         git_repo_path = os.path.join(

--- a/grader_service/autograding/local_grader.py
+++ b/grader_service/autograding/local_grader.py
@@ -17,7 +17,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from subprocess import CalledProcessError
-from typing import Optional
+from typing import List, Optional, Set
 
 from sqlalchemy.orm import Session
 from traitlets.config import Config
@@ -367,34 +367,54 @@ class LocalAutogradeExecutor(LoggingConfigurable):
             raise RuntimeError(f"Failed to push to {git_repo_path}")
         self.log.info("Pushing complete")
 
-    def commit_whitelisted_files(self):
-        self.log.info(f"Committing filtered files in {self.output_path}")
+    def _get_whitelist_patterns(self) -> Set[str]:
+        """
+        Combines all whitelist patterns into a single set.
+        """
         base_filter = ["*.ipynb"]
         extra_files = json.loads(self.assignment.properties).get("extra_files", [])
         allowed_file_patterns = self.assignment.settings.allowed_files
 
-        # combine all file patterns
-        file_patterns = set(base_filter + extra_files + allowed_file_patterns)
+        return set(base_filter + extra_files + allowed_file_patterns)
+
+    def _get_files_to_commit(self, file_patterns: Set[str]) -> List[str]:
+        """
+        Prepares a list of shell-escaped filenames matching the given patterns.
+
+        :param file_patterns: set of patterns to match the filenames against
+        :return: list of shell-escaped filenames
+        """
+        files_to_commit = []
 
         # get all files in the directory
-        files_to_commit = []
-        for root, _, files in os.walk(self.output_path):
+        for root, dirs, files in os.walk(self.output_path):
+            # Exclude .git directory - it contains subdirectories which we don't need to check
+            if ".git" in root:
+                continue
             rel_root = os.path.relpath(root, self.output_path)
             for file in files:
                 file_path = os.path.join(rel_root, file) if rel_root != "." else file
                 if any(fnmatch.fnmatch(file_path, pattern) for pattern in file_patterns):
                     files_to_commit.append(file_path)
 
+        # escape filenames to handle special characters and whitespaces
+        escaped_files = [shlex.quote(f) for f in files_to_commit]
+
+        return escaped_files
+
+    def commit_whitelisted_files(self):
+        self.log.info(f"Committing filtered files in {self.output_path}")
+
+        file_patterns = self._get_whitelist_patterns()
+        files_to_commit = self._get_files_to_commit(file_patterns)
+
         if not files_to_commit:
             self.log.info("No files to commit.")
             return
 
         try:
-            # escape filenames to handle special characters and whitespaces
-            escaped_files = [shlex.quote(f) for f in files_to_commit]
-
             # add only the filtered files
-            add_command = f"{self.git_executable} add -- " + " ".join(escaped_files)
+            add_command = f"{self.git_executable} add -- " + " ".join(files_to_commit)
             self._run_subprocess(add_command, self.output_path)
 
             # commit files

--- a/grader_service/convert/converters/autograde.py
+++ b/grader_service/convert/converters/autograde.py
@@ -2,7 +2,6 @@ import os
 from typing import Any
 
 from traitlets import List
-from traitlets.config.loader import Config
 
 from grader_service.api.models.assignment_settings import AssignmentSettings
 from grader_service.convert import utils
@@ -57,7 +56,7 @@ class Autograde(BaseConverter):
         self.log.info("Sanitizing %s", notebook_filename)
         self._sanitizing = True
         self._init_preprocessors()
-        super(Autograde, self).convert_single_notebook(notebook_filename)
+        super().convert_single_notebook(notebook_filename)
 
         notebook_filename = os.path.join(
             self.writer.build_directory, os.path.basename(notebook_filename)
@@ -67,7 +66,7 @@ class Autograde(BaseConverter):
         self._init_preprocessors()
         try:
             with utils.setenv(NBGRADER_EXECUTION="autograde"):
-                super(Autograde, self).convert_single_notebook(notebook_filename)
+                super().convert_single_notebook(notebook_filename)
         finally:
             self._sanitizing = True
 
@@ -81,7 +80,7 @@ class Autograde(BaseConverter):
                 self.init_single_notebook_resources(n)["unique_key"]: n for n in self.notebooks
             }
             for notebook in gb.model.notebook_id_set.difference(set(glob_notebooks.keys())):
-                self.log.warning("No submitted file: {}".format(notebook))
+                self.log.warning("No submitted file: %s", notebook)
                 nb = gb.find_notebook(notebook)
                 for grade in nb.grades:
                     grade.auto_score = 0
@@ -89,9 +88,6 @@ class Autograde(BaseConverter):
                     gb.add_grade(grade.id, notebook, grade)
 
         super().convert_notebooks()
-
-    def _load_config(self, cfg: Config, **kwargs: Any) -> None:
-        super(Autograde, self)._load_config(cfg, **kwargs)
 
     def __init__(
         self,
@@ -101,13 +97,8 @@ class Autograde(BaseConverter):
         assignment_settings: AssignmentSettings,
         **kwargs: Any,
     ) -> None:
-        super(Autograde, self).__init__(
-            input_dir, output_dir, file_pattern, assignment_settings, **kwargs
-        )
+        super().__init__(input_dir, output_dir, file_pattern, assignment_settings, **kwargs)
         self.force = True  # always overwrite generated assignments
-
-    def start(self) -> None:
-        super(Autograde, self).start()
 
 
 class AutogradeApp(ConverterApp):

--- a/grader_service/convert/converters/base.py
+++ b/grader_service/convert/converters/base.py
@@ -419,11 +419,11 @@ class BaseConverter(LoggingConfigurable):
             errors.append(e)
             _handle_failure(e)
 
-        if len(errors) > 0:
+        if errors:
             if self.logfile:
                 msg = (
-                    "Please see the error log ({}) for details on the specific "
-                    "errors on the above failures.".format(self.logfile)
+                    f"Please see the error log ({self.logfile}) for details on the specific "
+                    "errors on the above failures."
                 )
             else:
                 msg = errors[0]

--- a/grader_service/convert/converters/base.py
+++ b/grader_service/convert/converters/base.py
@@ -264,7 +264,8 @@ class BaseConverter(LoggingConfigurable):
 
         if allowed_files is None:
             self.log.info(
-                "No additional file patterns specified; only copying files included in release version"
+                "No additional file patterns specified; only copying files included "
+                "in release version"
             )
             files_patterns = gb.get_extra_files()
         else:
@@ -287,7 +288,8 @@ class BaseConverter(LoggingConfigurable):
             return any(fnmatch.fnmatch(file_path, pattern) for pattern in ignore_patterns)
 
         self.log.info(
-            f"Copying files from {src} to {dst} that match allowed patterns and don't match ignored patterns."
+            f"Copying files from {src} to {dst} that match allowed patterns "
+            f"and don't match ignored patterns."
         )
 
         for root, dirs, files in os.walk(src, topdown=True):

--- a/grader_service/convert/converters/base.py
+++ b/grader_service/convert/converters/base.py
@@ -35,7 +35,7 @@ class BaseConverter(LoggingConfigurable):
     force = Bool(False, help="Whether to overwrite existing files").tag(config=True)
 
     ignore = List(
-        [".ipynb_checkpoints", "*.pyc", "__pycache__", ".git", "*.ipynb"],
+        [".ipynb_checkpoints", "*.pyc", "__pycache__", ".git"],
         help=dedent(
             """
             List of file names or file globs.

--- a/grader_service/convert/converters/generate_assignment.py
+++ b/grader_service/convert/converters/generate_assignment.py
@@ -2,7 +2,6 @@ from textwrap import dedent
 from typing import Any
 
 from traitlets import Bool, List, default
-from traitlets.config.loader import Config
 
 from grader_service.api.models.assignment_settings import AssignmentSettings
 from grader_service.convert import utils
@@ -59,9 +58,6 @@ class GenerateAssignment(BaseConverter):
     # NB: ClearHiddenTests must come after ComputeChecksums and SaveCells.
     # ComputerChecksums must come again after ClearHiddenTests.
 
-    def _load_config(self, cfg: Config, **kwargs: Any) -> None:
-        super(GenerateAssignment, self)._load_config(cfg, **kwargs)
-
     def __init__(
         self,
         input_dir: str,
@@ -70,9 +66,7 @@ class GenerateAssignment(BaseConverter):
         assignment_settings: AssignmentSettings,
         **kwargs: Any,
     ) -> None:
-        super(GenerateAssignment, self).__init__(
-            input_dir, output_dir, file_pattern, assignment_settings, **kwargs
-        )
+        super().__init__(input_dir, output_dir, file_pattern, assignment_settings, **kwargs)
         self.force = True  # always overwrite generated assignments
 
     def start(self) -> None:

--- a/grader_service/convert/converters/generate_assignment.py
+++ b/grader_service/convert/converters/generate_assignment.py
@@ -23,6 +23,8 @@ from grader_service.convert.preprocessors import (
 
 
 class GenerateAssignment(BaseConverter):
+    """Convert between the 'source code' and the 'student version' of assignment files."""
+
     create_assignment = Bool(
         True,
         help=dedent(
@@ -68,9 +70,6 @@ class GenerateAssignment(BaseConverter):
     ) -> None:
         super().__init__(input_dir, output_dir, file_pattern, assignment_settings, **kwargs)
         self.force = True  # always overwrite generated assignments
-
-    def start(self) -> None:
-        super(GenerateAssignment, self).start()
 
 
 class GenerateAssignmentApp(ConverterApp):

--- a/grader_service/convert/gradebook/models.py
+++ b/grader_service/convert/gradebook/models.py
@@ -355,16 +355,13 @@ class GradeBookModel(BaseModel):
         return max_score
 
     @property
-    def notebook_id_set(self) -> Set[Notebook]:
+    def notebook_id_set(self) -> Set[str]:
         return {x for x in self.notebooks.keys()}
 
     @classmethod
     def from_dict(cls: Type["GradeBookModel"], d: dict) -> "GradeBookModel":
         ns = {id: Notebook.from_dict(v) for id, v in d["notebooks"].items()}
-        try:
-            extra_files = d["extra_files"]
-        except KeyError:
-            extra_files = []
+        extra_files = d.get("extra_files", [])
         return GradeBookModel(notebooks=ns, extra_files=extra_files)
 
     def to_dict(self) -> dict:

--- a/grader_service/handlers/assignment.py
+++ b/grader_service/handlers/assignment.py
@@ -171,16 +171,6 @@ class AssignmentBaseHandler(GraderBaseHandler):
         self.write_json(assignment)
 
 
-def get_allow_files(assignment_model: AssignmentModel):
-    """Extract the allow files from field in assignment table.
-
-    Return false if field is None, else a list."""
-    allow_files = False
-    if assignment_model.allow_files is not None:
-        allow_files = assignment_model.allow_files
-    return allow_files
-
-
 @register_handler(
     path=r"\/api\/lectures\/(?P<lecture_id>\d*)\/assignments\/(?P<assignment_id>\d*)\/?",
     version_specifier=VersionSpecifier.ALL,

--- a/grader_service/tests/autograding/test_local_grader.py
+++ b/grader_service/tests/autograding/test_local_grader.py
@@ -2,9 +2,9 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from grader_service.api.models.assignment_settings import AssignmentSettings
 from grader_service.autograding.local_grader import LocalAutogradeExecutor
 from grader_service.orm import Submission
-from grader_service.api.models.assignment_settings import AssignmentSettings
 
 
 @pytest.fixture

--- a/grader_service/tests/autograding/test_local_grader.py
+++ b/grader_service/tests/autograding/test_local_grader.py
@@ -1,0 +1,50 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from grader_service.autograding.local_grader import LocalAutogradeExecutor
+from grader_service.orm import Submission
+from grader_service.api.models.assignment_settings import AssignmentSettings
+
+
+@pytest.fixture
+def local_autograde_executor():
+    submission = Submission()
+    submission.assignment = MagicMock()
+    submission.id = 42
+
+    yield LocalAutogradeExecutor(grader_service_dir="foo", submission=submission)
+
+
+def test_get_whitelist_patterns(local_autograde_executor):
+    local_autograde_executor.assignment.properties = '{"extra_files": ["Introduction to numpy.md"]}'
+    local_autograde_executor.assignment.settings = AssignmentSettings(
+        allowed_files=["*.py", "*.ipynb"]
+    )
+
+    assert local_autograde_executor._get_whitelist_patterns() == {
+        "*.py",
+        "*.ipynb",
+        "Introduction to numpy.md",
+    }
+
+
+@patch("grader_service.autograding.local_grader.os.walk", autospec=True)
+def test_get_files_to_commit(mock_walk, local_autograde_executor):
+    mock_walk.return_value = [
+        (
+            "foo/convert_out/submission_42",
+            [".git", "bar"],
+            ["Ex1.ipynb", "output.txt", "weird name.py", "config"],
+        ),
+        ("foo/convert_out/submission_42/.git", ["refs"], ["config", "description", "HEAD"]),
+        ("foo/convert_out/submission_42/.git/refs", ["heads", "tags"], []),
+        ("foo/convert_out/submission_42/bar", [], ["Ex2.ipynb", "data.gz", "config"]),
+    ]
+
+    assert local_autograde_executor._get_files_to_commit({"*.ipynb", "*/config", "*.py"}) == [
+        "Ex1.ipynb",
+        "'weird name.py'",
+        "bar/Ex2.ipynb",
+        "bar/config",
+    ]

--- a/grader_service/tests/convert/converters/__init__.py
+++ b/grader_service/tests/convert/converters/__init__.py
@@ -1,5 +1,9 @@
 import shutil
 from pathlib import Path
+from typing import Any, Dict
+
+from grader_service.api.models.assignment_settings import AssignmentSettings
+from grader_service.convert.converters import GenerateAssignment
 
 tests_dir = Path(__file__).parent.parent
 
@@ -15,3 +19,21 @@ def _create_input_output_dirs(p: Path, input_notebooks=None):
             shutil.copyfile(tests_dir / f"preprocessors/files/{n}", input_dir / n)
 
     return input_dir, output_dir
+
+
+def _generate_test_assignment(
+    input_dir: str,
+    output_dir: str,
+    file_pattern: str = "*.ipynb",
+    assignment_settings_kwargs: Dict[str, Any] = None,
+):
+    if assignment_settings_kwargs is None:
+        assignment_settings_kwargs = {}
+
+    GenerateAssignment(
+        input_dir=input_dir,
+        output_dir=output_dir,
+        file_pattern=file_pattern,
+        assignment_settings=AssignmentSettings(**assignment_settings_kwargs),
+        config=None,
+    ).start()

--- a/grader_service/tests/convert/converters/test_autograde.py
+++ b/grader_service/tests/convert/converters/test_autograde.py
@@ -1,31 +1,31 @@
 import shutil
 from unittest.mock import patch
 
+from nbclient.client import NotebookClient
+
 from grader_service.api.models.assignment_settings import AssignmentSettings
-from grader_service.convert.converters import Autograde, GenerateAssignment
-from grader_service.tests.convert.converters import _create_input_output_dirs
+from grader_service.convert.converters import Autograde
+from grader_service.tests.convert.converters import (
+    _create_input_output_dirs,
+    _generate_test_assignment,
+)
 
 
 def test_autograde(tmp_path):
     input_dir, output_dir = _create_input_output_dirs(tmp_path, ["simple.ipynb"])
 
-    GenerateAssignment(
-        input_dir=str(input_dir),
-        output_dir=str(output_dir),
-        file_pattern="*.ipynb",
-        assignment_settings=AssignmentSettings(),
-        config=None,
-    ).start()
+    _generate_test_assignment(input_dir, output_dir)
 
     assert (output_dir / "simple.ipynb").exists()
     assert (output_dir / "gradebook.json").exists()
 
     output_dir2 = tmp_path / "output_dir2"
     output_dir2.mkdir()
-    shutil.copyfile(output_dir / "gradebook.json", output_dir2 / "gradebook.json")
-    assert (output_dir2 / "gradebook.json").exists()
 
-    from nbclient.client import NotebookClient
+    # The `gradebook.json` has to be copied manually so that the Autograde converter can keep track
+    # of which files were present originally. (In real life, `gradebook.json` would be copied
+    # by LocalAutogradeExecutor.)
+    shutil.copyfile(output_dir / "gradebook.json", output_dir2 / "gradebook.json")
 
     with patch.object(NotebookClient, "kernel_name", "python3"):
         Autograde(
@@ -42,28 +42,17 @@ def test_autograde(tmp_path):
 
 def test_autograde_copy_with_all_files(tmp_path):
     input_dir, output_dir = _create_input_output_dirs(tmp_path, ["simple.ipynb"])
-    test_file = input_dir / "test.txt"
+
+    _generate_test_assignment(
+        input_dir, output_dir, assignment_settings_kwargs={"allowed_files": ["*"]}
+    )
+
+    test_file = output_dir / "test.txt"
     test_file.touch()
-    assert test_file.exists()
-
-    GenerateAssignment(
-        input_dir=str(input_dir),
-        output_dir=str(output_dir),
-        file_pattern="*.ipynb",
-        assignment_settings=AssignmentSettings(allowed_files=["*"]),
-        config=None,
-    ).start()
-
-    assert (output_dir / "simple.ipynb").exists()
-    assert (output_dir / "gradebook.json").exists()
-    assert (output_dir / "test.txt").exists()
 
     output_dir2 = tmp_path / "output_dir2"
     output_dir2.mkdir()
     shutil.copyfile(output_dir / "gradebook.json", output_dir2 / "gradebook.json")
-    assert (output_dir2 / "gradebook.json").exists()
-
-    from nbclient.client import NotebookClient
 
     with patch.object(NotebookClient, "kernel_name", "python3"):
         Autograde(
@@ -79,40 +68,28 @@ def test_autograde_copy_with_all_files(tmp_path):
     assert (output_dir2 / "test.txt").exists()
 
 
-def test_generate_assignment_copy_with_dirs(tmp_path):
+def test_autograde_copy_with_dirs(tmp_path):
     input_dir, output_dir = _create_input_output_dirs(tmp_path, ["simple.ipynb"])
 
     dir_1 = input_dir / "dir_1"
     dir_2 = dir_1 / "dir_2"
     dir_3 = dir_2 / "dir_3"
     dir_3.mkdir(parents=True)
-    assert dir_3.exists()
 
     test_file = dir_3 / "test.txt"
     test_file.touch()
-    assert test_file.exists()
 
-    GenerateAssignment(
-        input_dir=str(input_dir),
-        output_dir=str(output_dir),
-        file_pattern="*.ipynb",
-        assignment_settings=AssignmentSettings(allowed_files=["*"]),
-        config=None,
-    ).start()
+    _generate_test_assignment(
+        input_dir, output_dir, assignment_settings_kwargs={"allowed_files": ["*"]}
+    )
 
     assert (output_dir / "simple.ipynb").exists()
     assert (output_dir / "gradebook.json").exists()
-    assert (output_dir / "dir_1").exists()
-    assert (output_dir / "dir_1/dir_2").exists()
-    assert (output_dir / "dir_1/dir_2/dir_3").exists()
     assert (output_dir / "dir_1/dir_2/dir_3/test.txt").exists()
 
     output_dir2 = tmp_path / "output_dir2"
     output_dir2.mkdir()
     shutil.copyfile(output_dir / "gradebook.json", output_dir2 / "gradebook.json")
-    assert (output_dir2 / "gradebook.json").exists()
-
-    from nbclient.client import NotebookClient
 
     with patch.object(NotebookClient, "kernel_name", "python3"):
         Autograde(
@@ -129,3 +106,38 @@ def test_generate_assignment_copy_with_dirs(tmp_path):
     assert (output_dir2 / "dir_1/dir_2").exists()
     assert (output_dir2 / "dir_1/dir_2/dir_3").exists()
     assert (output_dir2 / "dir_1/dir_2/dir_3/test.txt").exists()
+
+
+def test_autograde_with_student_notebooks_copied_over(tmp_path):
+    """Regression test: When assignment's allowed_files contain '*.ipynb', then notebooks created
+    by the student should also be copied over."""
+    input_dir, output_dir = _create_input_output_dirs(tmp_path, ["simple.ipynb"])
+
+    _generate_test_assignment(input_dir, output_dir)
+
+    student_nb = output_dir / "student.ipynb"
+    student_nb.touch()
+
+    output_dir2 = tmp_path / "output_dir2"
+    output_dir2.mkdir()
+    shutil.copyfile(output_dir / "gradebook.json", output_dir2 / "gradebook.json")
+
+    with (
+        patch.object(NotebookClient, "kernel_name", "python3"),
+        patch(
+            "grader_service.convert.converters.autograde.Autograde.convert_single_notebook"
+        ) as convert_mock,
+    ):
+        Autograde(
+            input_dir=str(output_dir),
+            output_dir=str(output_dir2),
+            file_pattern="*.ipynb",
+            assignment_settings=AssignmentSettings(allowed_files=["*.ipynb"]),
+            config=None,
+        ).start()
+
+    assert (output_dir2 / "simple.ipynb").exists()
+    assert (output_dir2 / "gradebook.json").exists()
+    assert (output_dir2 / "student.ipynb").exists()
+
+    assert convert_mock.call_count == 2  # `convert_single_notebook` was called for both notebooks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,19 +30,20 @@ dependencies = [
     "jupyter-client>=8.6",
     "jupyter_core>=5.7",
     "jupyterhub>=5",
+    "jupyterlab>=4.4.4",
     "kubernetes>=31",
     "nbconvert>=7.16",
     "nbformat>=5.4.0",
+    "pandas>=2.2.3",
     "psycopg2-binary>= 2.9",
     "PyJWT>=2.9",
-    "python-dateutil>=2.9", 
+    "python-dateutil>=2.9",
     "SQLAlchemy>=2.0.35",
     "tornado>=6.4",
     "traitlets>=5.14",
     "typing-extensions>=4.12",
     "urllib3>=2.2",
-    "pandas>=2.2.3",
-    "uvloop>=0.21.0"
+    "uvloop>=0.21.0",
 ]
 
 [tool.setuptools]

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,6 +1,7 @@
 pytest>=6.2.3
 pytest-asyncio>=0.15.1
 pytest-cov>=2.12.1
+pytest-jupyter>=0.10.1
 pytest-mock>=3.6.0
 pytest-httpserver>=1.0.2
 pytest-tornasync>=0.6.0


### PR DESCRIPTION
The fix itself (and a regression test) is in 06a69caeda92efa8dc47c1734dc786e4a396c0c2.

I also broke down the `LocalAutogradeExecutor.commit_whitelisted_files` into smaller functions (seems cleaner to me!). I wrote tests for those smaller functions, because I initially thought the bug was there - but this part actually worked fine; nevertheless I left the tests in place (even though these are 'private' methods, so in principle they can change, and then the tests will break... I can also remove these tests, if you think it makes more sense.) 

I also improved small things that I stumbled across in the meantime. See the commit list for more details about these changes.