### PR TITLE
Docs: Fix chart name

### DIFF
--- a/docs/source/installation/kubernetes.md
+++ b/docs/source/installation/kubernetes.md
@@ -14,7 +14,7 @@
 ## Install Grader Service
 If you already have a JupyterHub installation, you can also install only the Grader Service using Helm:
 ```bash
-helm upgrade --install <your-release-name> grader-service \
+helm upgrade --install <your-release-name> grader-service/grader-service \
     --namespace <your-namespace> \
     --create-namespace \
     --values <your-values.yaml>


### PR DESCRIPTION
We are currently about to test and install the Grader Service with [authentication mode 1](https://grader-service.readthedocs.io/en/latest/configuration/auth.html#mode-1-jupyterhub-provides-api-token) using the documentation.

To avoid multiple pull requests targeting only a few sentences in the documentation, I would collect all further suggestions and open a PR at the end if that works out for you.