### PR TITLE
Helm chart modifications for OpenShift

### DIFF
--- a/charts/grader-service/templates/deployment.yaml
+++ b/charts/grader-service/templates/deployment.yaml
@@ -94,7 +94,7 @@ spec:
         - name: volume-permissions
           image: busybox
           command: ["/bin/sh","-c"]
-          args: ["chown 1000:1000 /var/lib/grader-service;"]
+          args: ["chown -R 1000:1000 /var/lib/grader-service;"]
           volumeMounts:
             - name: data
               mountPath: /var/lib/grader-service

--- a/charts/grader-service/templates/rabbitmq.yaml
+++ b/charts/grader-service/templates/rabbitmq.yaml
@@ -4,6 +4,10 @@ metadata:
   name: rabbitmq-grader-service
   labels:
     {{- include "grader-service.labels" . | nindent 4 }}
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    meta.helm.sh/release-name: {{ .Release.Name }}
+    meta.helm.sh/release-namespace: {{ .Release.Namespace }}
   namespace: {{ .Release.Namespace }}
 spec:
   replicas: 1

--- a/charts/grader-service/templates/rabbitmq.yaml
+++ b/charts/grader-service/templates/rabbitmq.yaml
@@ -13,6 +13,8 @@ spec:
   replicas: 1
   resources:
     {{- toYaml .Values.rabbitmq.resources | nindent 4 }}
+  override:
+    {{- toYaml .Values.rabbitmq.override | nindent 4 }}
   rabbitmq:
     additionalConfig: |
       consumer_timeout = 31622400000

--- a/charts/grader-service/templates/role.yaml
+++ b/charts/grader-service/templates/role.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.serviceAccount.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -11,3 +12,4 @@ rules:
       - pods/status
       - pods/log
     verbs: ["get", "create", "update", "delete"]
+{{- end }}

--- a/charts/grader-service/templates/rolebinding.yaml
+++ b/charts/grader-service/templates/rolebinding.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.serviceAccount.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -10,3 +11,4 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: {{ include "grader-service.serviceAccountName" . }}
+{{- end }}

--- a/charts/grader-service/values.yaml
+++ b/charts/grader-service/values.yaml
@@ -115,6 +115,7 @@ rabbitmq:
       limits:
         cpu: 2
         memory: 4Gi
+  override: {}
 
 workers:
   replication: 1

--- a/docs/ReadMe.md
+++ b/docs/ReadMe.md
@@ -1,6 +1,6 @@
 # Sphinx documentation
 ## Requirements
-``pip install -r requirements-docs.txt``
+``pip install -r docs-requirements.txt``
 ## Usage
 Generate documentation:
 ``make html``

--- a/docs/source/configuration/auth.md
+++ b/docs/source/configuration/auth.md
@@ -81,6 +81,7 @@ After the user is authenticated, the Grader Service can be configured to create 
 from grader_service.auth.token import JupyterHubTokenAuthenticator
 
 c.GraderService.authenticator_class = JupyterHubTokenAuthenticator
+c.Authenticator.allow_all = True
 c.JupyterHubTokenAuthenticator.user_info_url = "<jupyterhub-url>/hub/api/user"
 
 def post_auth_hook(authenticator: Authenticator, handler: BaseHandler, authentication: dict):

--- a/docs/source/installation/kubernetes.md
+++ b/docs/source/installation/kubernetes.md
@@ -10,6 +10,7 @@
     ```bash
     helm repo add grader-service ghcr.io/tu-wien-datalab/grader-service
     ```
+- [RabbitMQ operator](https://www.rabbitmq.com/kubernetes/operator/install-operator#installation) installed
 
 ## Install Grader Service
 If you already have a JupyterHub installation, you can also install only the Grader Service using Helm:


### PR DESCRIPTION
To run the grader service on a Red Hat OpenShift cluster, we made some changes to the chart.
Since it may be of interest to other users in the future as well, and it does not introduce breaking changes, we would like to contribute our suggestions rather than maintain a separate fork.

- We first disabled the init container `volume-permissions`. After enabling it, only the permission of `/var/lib/grader-service` changed, but not of the already existing files. Thus, we propose adding the flag `-R` to apply permissions recursively to all files.
- We added some labels and annotations to the RabbitMQ cluster so Helm also manages it. Otherwise, `helm uninstall` does not delete it, and another `helm install` leads to the following error:

  ```
  Error: Unable to continue with install: RabbitmqCluster "rabbitmq-grader-service" in namespace "grader-service" exists and cannot be imported into the current release: invalid ownership metadata; label validation error: missing key "app.kubernetes.io/managed-by": must be set to "Helm"; annotation validation error: missing key "meta.helm.sh/release-name": must be set to "grader-service"; annotation validation error: missing key "meta.helm.sh/release-namespace": must be set to "grader-service"
  ```
- OpenShift requires a dedicated service account because we have to grant `anyuid` permissions to run the container as user `1000`. Thus, we must disable auto-creation and create it manually. Therefore, we suggest only creating the `Role` and `RoleBinding` if a service account should be created.
- Similarly, we have to adjust RabbitMQ's security context. Therefore, we added another config property to the Helm chart values to modify the property `override`, similar to the already existing template for `resources`.
- The other changes only affect the documentation.

Please let me know if the changes sound reasonable to you. I'm also happy to make further modifications.