### PR TITLE
fix: Set missing display_name for a new user in auth_to_user

### DIFF
--- a/grader_service/handlers/base_handler.py
+++ b/grader_service/handlers/base_handler.py
@@ -529,6 +529,7 @@ class BaseHandler(web.RequestHandler):
             self.log.info(f"User {username} does not exist and will be created.")
             user_model = User()
             user_model.name = username
+            user_model.display_name = username
             self.session.add(user_model)
             self.session.commit()
 


### PR DESCRIPTION
I recreated my db, and discovered yet another place where the display_name needs to be set.

Feel free to merge!