### PR TITLE
Fix: (soft-)delete submission endpoint

### DIFF
--- a/grader_service/handlers/base_handler.py
+++ b/grader_service/handlers/base_handler.py
@@ -788,10 +788,10 @@ class GraderBaseHandler(BaseHandler):
         if (
             (submission is None)
             or (submission.assignid != assignment_id)
-            or (int(submission.assignment.lectid) != int(lecture_id))
+            or (int(submission.assignment.lectid) != lecture_id)
             or (submission.deleted == DeleteState.deleted)
         ):
-            msg = "Submission with id " + str(submission_id) + " was not found"
+            msg = f"Submission with id {submission_id} was not found"
             raise HTTPError(HTTPStatus.NOT_FOUND, reason=msg)
         return submission
 

--- a/grader_service/handlers/handler_utils.py
+++ b/grader_service/handlers/handler_utils.py
@@ -5,24 +5,26 @@
 # LICENSE file in the root directory of this source tree.
 import enum
 from http import HTTPStatus
+from typing import Union
 
 from tornado.web import HTTPError
 
 
-def parse_ids(*args):
+def parse_ids(*args) -> Union[int, tuple[int, ...]]:
     """
-    Transforms loose ids to an id tuple.
+    Validates that provided args are all integers.
 
     :param args: certain amount of id (int) values
-    :return: tuple of ids
+    :return: tuple of ids as ints, or a single id if only one was provided
+    :raises HTTPError: if args contain invalid ids which cannot be cast to int
     """
     try:
-        ids = [int(id) for id in args]
+        ids = tuple(int(id) for id in args)
     except ValueError:
         raise HTTPError(HTTPStatus.BAD_REQUEST, reason="All IDs have to be numerical")
     if len(ids) == 1:
         return ids[0]
-    return tuple(ids)
+    return ids
 
 
 class GitRepoType(enum.StrEnum):

--- a/grader_service/handlers/submissions.py
+++ b/grader_service/handlers/submissions.py
@@ -492,7 +492,7 @@ class SubmissionObjectHandler(GraderBaseHandler):
         self.write_json(sub)
 
     @authorize([Scope.student, Scope.tutor, Scope.instructor])
-    def delete(self, lecture_id: int, assignment_id: int, submission_id: int):
+    async def delete(self, lecture_id: int, assignment_id: int, submission_id: int):
         """Soft-deletes a specific submission.
 
         :param lecture_id: id of the lecture

--- a/grader_service/handlers/submissions.py
+++ b/grader_service/handlers/submissions.py
@@ -501,8 +501,9 @@ class SubmissionObjectHandler(GraderBaseHandler):
         :type assignment_id: int
         :param submission_id: id of the submission
         :type submission_id: int
-        :raises HTTPError: if submission can't be deleted due to it having feedback
-            or the deadline having passed.
+        :raises HTTPError: if submission has feedback, or the deadline has passed,
+            or it has already been (soft-)deleted, or it belongs to another student,
+            or it was not found in the given lecture and assignment.
         """
         lecture_id, assignment_id, submission_id = parse_ids(
             lecture_id, assignment_id, submission_id

--- a/grader_service/handlers/submissions.py
+++ b/grader_service/handlers/submissions.py
@@ -491,8 +491,9 @@ class SubmissionObjectHandler(GraderBaseHandler):
         self.session.commit()
         self.write_json(sub)
 
+    @authorize([Scope.student, Scope.tutor, Scope.instructor])
     def delete(self, lecture_id: int, assignment_id: int, submission_id: int):
-        """Soft-Deletes a specific submission.
+        """Soft-deletes a specific submission.
 
         :param lecture_id: id of the lecture
         :type lecture_id: int
@@ -501,6 +502,7 @@ class SubmissionObjectHandler(GraderBaseHandler):
         :param submission_id: id of the submission
         :type submission_id: int
         :raises HTTPError: if submission can't be deleted due to it having feedback
+            or the deadline having passed.
         """
         lecture_id, assignment_id, submission_id = parse_ids(
             lecture_id, assignment_id, submission_id
@@ -508,39 +510,34 @@ class SubmissionObjectHandler(GraderBaseHandler):
         self.validate_parameters()
         submission = self.get_submission(lecture_id, assignment_id, submission_id)
 
-        if submission is not None:
-            if submission.feedback_status != "not_generated":
-                raise HTTPError(
-                    HTTPStatus.FORBIDDEN, reason="Only submissions without feedback can be deleted."
-                )
-            # if assignment has deadline
-            if submission.assignment.settings.deadline:
-                # if assignment's deadline has passed
-                if submission.assignment.settings.deadline < datetime.datetime.now(
-                    datetime.timezone.utc
-                ):
-                    raise HTTPError(
-                        HTTPStatus.FORBIDDEN,
-                        reason="Submission can't be deleted, due date of assigment has passed.",
-                    )
-            else:
-                previously_deleted = (
-                    self.session.query(Submission)
-                    .filter(
-                        Submission.id == submission_id,
-                        Submission.assignid == assignment_id,
-                        Submission.deleted == DeleteState.deleted,
-                    )
-                    .one_or_none()
-                )
-                if previously_deleted is not None:
-                    self.session.delete(previously_deleted)
-                    self.session.commit()
-
-                submission.deleted = DeleteState.deleted
-                self.session.commit()
-        else:
+        if submission is None:
             raise HTTPError(HTTPStatus.NOT_FOUND, reason="Submission to delete not found.")
+
+        # Do not allow students to delete other users' submissions
+        if (
+            self.get_role(lecture_id).role < Scope.instructor
+            and submission.username != self.user.name
+        ):
+            raise HTTPError(HTTPStatus.NOT_FOUND, reason="Submission to delete not found.")
+
+        if submission.feedback_status != "not_generated":
+            raise HTTPError(
+                HTTPStatus.FORBIDDEN, reason="Only submissions without feedback can be deleted."
+            )
+
+        # if assignment has deadline and it has already passed
+        if (
+            submission.assignment.settings.deadline
+            and submission.assignment.settings.deadline
+            < datetime.datetime.now(datetime.timezone.utc)
+        ):
+            raise HTTPError(
+                HTTPStatus.FORBIDDEN,
+                reason="Submission can't be deleted, due date of assigment has passed.",
+            )
+
+        submission.deleted = DeleteState.deleted
+        self.session.commit()
 
 
 @register_handler(

--- a/grader_service/tests/handlers/db_util.py
+++ b/grader_service/tests/handlers/db_util.py
@@ -102,7 +102,7 @@ def _get_submission(assignment_id, username, feedback="not_generated", score=Non
     s.display_name = username
     s.score = score
     s.commit_hash = secrets.token_hex(20)
-    s.feedback_available = feedback
+    s.feedback_status = feedback
     return s
 
 

--- a/grader_service/tests/handlers/test_submissions_handler.py
+++ b/grader_service/tests/handlers/test_submissions_handler.py
@@ -345,13 +345,13 @@ async def test_get_submissions_best_instructor_version(
     )
 
     insert_submission(
-        engine, assignment_id=a_id, username=default_user.name, feedback=True, score=3
+        engine, assignment_id=a_id, username=default_user.name, feedback="generated", score=3
     )
     insert_submission(
         engine,
         assignment_id=a_id,
         username=default_user.name,
-        feedback=False,
+        feedback="not_generated",
         with_properties=False,
     )
     insert_submission(engine, assignment_id=a_id, username="user1", score=3)


### PR DESCRIPTION
I found some further issues with the `delete` endpoint for submissions that we refactored together:

 - the method was not async (I assume that was an oversight??)
 - there was no `@authorize` decorator added to it (also an oversight, I suppose?)
 - any student could delete another student's submission, as long as it was found in the given lecture and assignment. Now only an instructor/admin can do this.

I also wrote a few tests for this endpoint, because there weren't any.