### PR TITLE
Fix: Do not delete api tokens with `client_id=None`

### DIFF
--- a/grader_service/migrate/versions/4a88dacd888f_add_ondelete_cascade.py
+++ b/grader_service/migrate/versions/4a88dacd888f_add_ondelete_cascade.py
@@ -266,13 +266,17 @@ def upgrade():
         ],
     )
 
-    # invalid “api_token” entries are deleted
+    # OAuth/LTI tokens that reference non-existent clients are deleted
     connection.execute(
-        text("""
+        text(
+            """
              DELETE
              FROM api_token
-             WHERE client_id NOT IN (SELECT identifier FROM oauth_client)
-             """)
+             WHERE
+               client_id IS NOT NULL  -- non-OAuth tokens may not have client_id set
+               AND client_id NOT IN (SELECT identifier FROM oauth_client);
+             """
+        )
     )
     _upgrade_recreate_foreign_keys(
         connection=connection,


### PR DESCRIPTION
E.g. JupyterHub tokens do not set client_id, so we'd rather not delete them when applying the migration.