### PR TITLE
Fix/improve error handling in handlers

### DIFF
--- a/grader_service/auth/lti13/handlers.py
+++ b/grader_service/auth/lti13/handlers.py
@@ -11,6 +11,7 @@ from tornado.httputil import url_concat
 from tornado.log import app_log
 from tornado.web import HTTPError, MissingArgumentError, RequestHandler
 
+from grader_service.errors import APIError
 from grader_service.handlers.base_handler import BaseHandler
 from grader_service.utils import convert_request_to_dict, url_path_join
 
@@ -365,14 +366,14 @@ class LTI13CallbackHandler(BaseHandler):
         try:
             id_token = self.decode_and_validate_launch_request()
         except InvalidAudienceError as e:
-            raise HTTPError(401, reason=str(e))
+            raise APIError(401, message=str(e))
         except ValidationError as e:
-            raise HTTPError(400, reason=str(e))
+            raise APIError(400, message=str(e))
 
         try:
             user = await self.login_user(id_token)
         except LoginError as e:
-            raise HTTPError(400, reason=str(e))
+            raise APIError(400, message=str(e))
         self.log.debug(f"user logged in: {user}")
         if user is None:
             raise HTTPError(403, reason="User missing or null")

--- a/grader_service/errors.py
+++ b/grader_service/errors.py
@@ -1,0 +1,11 @@
+"""Module defining custom error classes for the grader service."""
+
+from tornado.web import HTTPError
+
+
+class APIError(HTTPError):
+    """Base class for API-related errors."""
+
+    def __init__(self, status_code: int, message: str, **kwargs):
+        super().__init__(status_code, **kwargs)
+        self.message = message

--- a/grader_service/handlers/assignment.py
+++ b/grader_service/handlers/assignment.py
@@ -15,6 +15,7 @@ from tornado.web import HTTPError
 from grader_service.api.models.assignment import Assignment as AssignmentModel
 from grader_service.api.models.assignment_settings import AssignmentSettings
 from grader_service.convert.gradebook.models import GradeBookModel
+from grader_service.errors import APIError
 from grader_service.handlers.base_handler import GraderBaseHandler, authorize
 from grader_service.handlers.submissions import SubmissionHandler
 from grader_service.orm.assignment import Assignment
@@ -135,13 +136,13 @@ class AssignmentBaseHandler(GraderBaseHandler):
         self.validate_parameters()
         role = self.get_role(lecture_id)
         if role.lecture.deleted == DeleteState.deleted:
-            raise HTTPError(HTTPStatus.NOT_FOUND)
+            raise HTTPError(HTTPStatus.NOT_FOUND, reason="Lecture was deleted")
         try:
             body = tornado.escape.json_decode(self.request.body)
             assignment_model = AssignmentModel.from_dict(body)
         except ValueError as e:
             # TODO Return useful error message
-            raise HTTPError(HTTPStatus.BAD_REQUEST, reason=str(e))
+            raise APIError(HTTPStatus.BAD_REQUEST, message=str(e))
         assignment = Assignment()
 
         assignment.name = assignment_model.name
@@ -317,7 +318,7 @@ class AssignmentObjectHandler(GraderBaseHandler):
                 self.delete_assignment_files(assignment=assignment, lecture=lecture)
             else:
                 if assignment.deleted == DeleteState.deleted:
-                    raise HTTPError(HTTPStatus.NOT_FOUND)
+                    raise HTTPError(HTTPStatus.NOT_FOUND, reason="Assignment was deleted.")
 
                 self.validate_assignment_for_soft_delete(assignment=assignment)
                 previously_deleted = self.delete_previous_assignment(

--- a/grader_service/handlers/base_handler.py
+++ b/grader_service/handlers/base_handler.py
@@ -1121,7 +1121,6 @@ class GraderBaseHandler(GraderErrorMixin, BaseHandler):
             ret = subprocess.run(shlex.split(command), check=True, cwd=cwd, capture_output=True)
         except subprocess.CalledProcessError as e:
             self.log.error(e.stderr)
-            # TODO: do we want to replace this with APIError?
             raise HTTPError(500, reason="Subprocess Error")
         except FileNotFoundError as e:
             self.log.error(e)
@@ -1155,7 +1154,6 @@ class GraderBaseHandler(GraderErrorMixin, BaseHandler):
         stdout, stderr = await ret.communicate()
         if ret.returncode != 0:
             self.log.error(stderr.decode())
-            # TODO: do we want to replace this with APIError?
             raise HTTPError(500, reason="Subprocess Error")
         return stdout.decode()
 

--- a/grader_service/handlers/base_handler.py
+++ b/grader_service/handlers/base_handler.py
@@ -86,7 +86,7 @@ def check_authorization(
             self.user.name,
             self.request.path,
         )
-        raise HTTPError(403)
+        raise HTTPError(403, reason="Permission denied")
     return True
 
 
@@ -780,7 +780,7 @@ class GraderBaseHandler(BaseHandler):
     def get_role(self, lecture_id: int) -> Role:
         role: Optional[Role] = self.session.get(Role, (self.user.id, lecture_id))
         if role is None:
-            raise HTTPError(403)
+            raise HTTPError(403, reason="No role found")
         return role
 
     def get_lecture(self, lecture_id: int) -> Lecture:
@@ -1106,6 +1106,7 @@ class GraderBaseHandler(BaseHandler):
             ret = subprocess.run(shlex.split(command), check=True, cwd=cwd, capture_output=True)
         except subprocess.CalledProcessError as e:
             self.log.error(e.stderr)
+            # TODO: do we want to replace this with APIError?
             raise HTTPError(500, reason="Subprocess Error")
         except FileNotFoundError as e:
             self.log.error(e)
@@ -1139,6 +1140,7 @@ class GraderBaseHandler(BaseHandler):
         stdout, stderr = await ret.communicate()
         if ret.returncode != 0:
             self.log.error(stderr.decode())
+            # TODO: do we want to replace this with APIError?
             raise HTTPError(500, reason="Subprocess Error")
         return stdout.decode()
 
@@ -1175,13 +1177,13 @@ def authenticated(
     """Decorate methods with this to require that the user be logged in.
 
     If the user is not logged in `tornado.web.HTTPError`
-    with code 403 will be raised.
+    with code 401 will be raised.
     """
 
     @functools.wraps(method)
     def wrapper(self: GraderBaseHandler, *args, **kwargs) -> Optional[Awaitable[None]]:
         if not self.current_user:
-            raise HTTPError(403)
+            raise HTTPError(401, reason="User not authenticated")
         return method(self, *args, **kwargs)
 
     return wrapper

--- a/grader_service/handlers/base_handler.py
+++ b/grader_service/handlers/base_handler.py
@@ -766,14 +766,7 @@ class BaseHandler(web.RequestHandler):
         return url
 
 
-class GraderBaseHandler(BaseHandler):
-    def validate_parameters(self, *args):
-        if len(self.request.arguments) == 0:
-            return
-        unknown_args = set(self.request.query_arguments.keys()) - set(args)
-        if len(unknown_args) != 0:
-            raise HTTPError(400, reason=f"Unknown arguments: {unknown_args}")
-
+class GraderErrorMixin:
     def write_error(self, status_code, **kwargs):
         self.log.error("Error %s: %s", status_code, self._reason)
 
@@ -789,6 +782,15 @@ class GraderBaseHandler(BaseHandler):
             self.finish(json.dumps(reply))
         else:
             super().write_error(status_code, exc_info=exc)
+
+
+class GraderBaseHandler(GraderErrorMixin, BaseHandler):
+    def validate_parameters(self, *args):
+        if len(self.request.arguments) == 0:
+            return
+        unknown_args = set(self.request.query_arguments.keys()) - set(args)
+        if len(unknown_args) != 0:
+            raise HTTPError(400, reason=f"Unknown arguments: {unknown_args}")
 
     def get_role(self, lecture_id: int) -> Role:
         role: Optional[Role] = self.session.get(Role, (self.user.id, lecture_id))

--- a/grader_service/handlers/base_handler.py
+++ b/grader_service/handlers/base_handler.py
@@ -37,6 +37,7 @@ from traitlets.config import SingletonConfigurable
 from grader_service import __version__
 from grader_service.api.models.base_model import Model
 from grader_service.autograding.local_grader import LocalAutogradeExecutor
+from grader_service.errors import APIError
 from grader_service.handlers.handler_utils import GitRepoType
 from grader_service.orm import APIToken, Assignment, Submission
 from grader_service.orm.base import DeleteState, Serializable
@@ -775,7 +776,19 @@ class GraderBaseHandler(BaseHandler):
 
     def write_error(self, status_code, **kwargs):
         self.log.error("Error %s: %s", status_code, self._reason)
-        return super().write_error(status_code, **kwargs)
+
+        exc = kwargs.get("exc_info", (None, None, None))[1]
+        if isinstance(exc, APIError):
+            self.set_header("Content-Type", "application/json")
+
+            reply = {"status": status_code, "message": exc.message}
+
+            if exc.reason is not None:
+                reply["error"] = exc.reason
+
+            self.finish(json.dumps(reply))
+        else:
+            super().write_error(status_code, exc_info=exc)
 
     def get_role(self, lecture_id: int) -> Role:
         role: Optional[Role] = self.session.get(Role, (self.user.id, lecture_id))

--- a/grader_service/handlers/git/server.py
+++ b/grader_service/handlers/git/server.py
@@ -17,6 +17,7 @@ from tornado.iostream import StreamClosedError
 from tornado.process import Subprocess
 from tornado.web import HTTPError, stream_request_body
 
+from grader_service.errors import APIError
 from grader_service.handlers.base_handler import GraderBaseHandler, RequestHandlerConfig
 from grader_service.handlers.handler_utils import GitRepoType
 from grader_service.orm.lecture import Lecture
@@ -71,7 +72,7 @@ class GitBaseHandler(GraderBaseHandler):
             pass
         except Exception as e:
             self.log.error(f"Error from git response {e}")
-            raise HTTPError(500, str(e))
+            raise APIError(500, message=str(e))
 
     def _check_git_repo_permissions(self, rpc: str, role: Role, pathlets: List[str]):
         repo_type: str = pathlets[2]

--- a/grader_service/handlers/lectures.py
+++ b/grader_service/handlers/lectures.py
@@ -140,7 +140,7 @@ class LectureObjectHandler(GraderBaseHandler):
 
         :param lecture_id: id of the lecture
         :type lecture_id: int
-        :raises ,HTTPError: throws err if lecture was already deleted
+        :raises HTTPError: throws err if lecture was already deleted
         or was not found
 
         """

--- a/grader_service/handlers/lectures.py
+++ b/grader_service/handlers/lectures.py
@@ -140,7 +140,7 @@ class LectureObjectHandler(GraderBaseHandler):
 
         :param lecture_id: id of the lecture
         :type lecture_id: int
-        :raises HTTPError: throws err if lecture was already deleted
+        :raises ,HTTPError: throws err if lecture was already deleted
         or was not found
 
         """
@@ -163,7 +163,7 @@ class LectureObjectHandler(GraderBaseHandler):
                 self.delete_lecture_files(lecture)
             else:
                 if lecture.deleted == DeleteState.deleted:
-                    raise HTTPError(HTTPStatus.NOT_FOUND)
+                    raise HTTPError(HTTPStatus.NOT_FOUND, reason="Lecture was deleted.")
 
                 # Collect previous duplicates and delete them before commit
                 # to prevent UNIQUE constraint violations when soft-deleting current assignments

--- a/grader_service/handlers/submissions.py
+++ b/grader_service/handlers/submissions.py
@@ -28,6 +28,7 @@ from grader_service.autograding.celery.tasks import (
     lti_sync_task,
 )
 from grader_service.convert.gradebook.models import GradeBookModel
+from grader_service.errors import APIError
 from grader_service.handlers.base_handler import GraderBaseHandler, authorize
 from grader_service.handlers.handler_utils import GitRepoType, parse_ids
 from grader_service.orm.assignment import Assignment
@@ -958,7 +959,7 @@ class LtiSyncHandler(GraderBaseHandler):
             except Exception as e:
                 err_msg = f"Could not process submission IDs: {e}"
                 self.log.error(err_msg)
-                raise HTTPError(HTTPStatus.BAD_REQUEST, reason=err_msg)
+                raise APIError(HTTPStatus.BAD_REQUEST, message=err_msg)
 
         lti_plugin = LTISyncGrades.instance()
         lecture_model = lecture.serialize()
@@ -975,7 +976,7 @@ class LtiSyncHandler(GraderBaseHandler):
             except HTTPError as e:
                 err_msg = f"Could not sync grades: {e.reason}"
                 self.log.info(err_msg)
-                raise HTTPError(HTTPStatus.INTERNAL_SERVER_ERROR, reason=err_msg)
+                raise APIError(HTTPStatus.INTERNAL_SERVER_ERROR, message=err_msg)
             except Exception as e:
                 self.log.error("Could not sync grades: " + str(e))
                 raise HTTPError(500, reason="An unexpected error occurred.")

--- a/grader_service/oauth2/handlers.py
+++ b/grader_service/oauth2/handlers.py
@@ -10,6 +10,7 @@ from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 from oauthlib import oauth2
 from tornado import web
 
+from grader_service.errors import APIError
 from grader_service.handlers.base_handler import BaseHandler
 from grader_service.orm.api_token import APIToken
 from grader_service.utils import get_browser_protocol, url_path_join
@@ -218,7 +219,7 @@ class OAuthAuthorizeHandler(OAuthHandler, BaseHandler):
 
         # Errors that should be shown to the user on the provider website
         except oauth2.FatalClientError as e:
-            raise web.HTTPError(e.status_code, e.description)
+            raise APIError(e.status_code, message=e.description)
 
         # Errors embedded in the redirect URI back to the client
         except oauth2.OAuth2Error as e:
@@ -242,7 +243,7 @@ class OAuthAuthorizeHandler(OAuthHandler, BaseHandler):
                 uri, http_method, body, headers, scopes, credentials
             )
         except oauth2.FatalClientError as e:
-            raise web.HTTPError(e.status_code, e.description)
+            raise APIError(e.status_code, message=e.description)
         else:
             self.send_oauth_response(headers, body, status)
 
@@ -257,7 +258,7 @@ class OAuthTokenHandler(OAuthHandler, BaseHandler):
                 uri, http_method, body, headers, credentials
             )
         except oauth2.FatalClientError as e:
-            raise web.HTTPError(e.status_code, e.description)
+            raise APIError(e.status_code, message=e.description)
         else:
             self.send_oauth_response(headers, body, status)
 

--- a/grader_service/plugins/lti.py
+++ b/grader_service/plugins/lti.py
@@ -12,6 +12,8 @@ from tornado.web import HTTPError
 from traitlets import Bool, Callable, Unicode, Union
 from traitlets.config import SingletonConfigurable
 
+from grader_service.errors import APIError
+
 
 def default_lti_username_match(member, submission, log) -> bool:
     return False
@@ -297,8 +299,8 @@ class LTISyncGrades(SingletonConfigurable):
         try:
             encoded = jwt.encode(payload, private_key, algorithm="RS256", headers=headers)
         except Exception as e:
-            raise HTTPError(
-                HTTPStatus.UNPROCESSABLE_ENTITY, reason=f"Unable to encode payload: {str(e)}"
+            raise APIError(
+                HTTPStatus.UNPROCESSABLE_ENTITY, message=f"Unable to encode payload: {str(e)}"
             )
         scopes = [
             "https://purl.imsglobal.org/spec/lti-ags/scope/score",


### PR DESCRIPTION
This PR is related to issue #343.

It introduces a new custom error `APIError` that allows passing general-purpose error messages. It's used both in frontend and backend. 