### PR TITLE
fix: remove `jupyterlab` dependency from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,6 @@ dependencies = [
     "jupyter-client>=8.6",
     "jupyter_core>=5.7",
     "jupyterhub>=5",
-    "jupyterlab>=4.4.4",
     "kubernetes>=31",
     "nbconvert>=7.16",
     "nbformat>=5.4.0",


### PR DESCRIPTION
This PR is related to issue #344.