### PR TITLE
Enhance chart customization

### DIFF
--- a/charts/grader-service/templates/_helpers.tpl
+++ b/charts/grader-service/templates/_helpers.tpl
@@ -56,3 +56,94 @@ Create the name of the service account to use
 {{- define "grader-service.serviceAccountName" -}}
 {{- include "grader-service.fullname" . }}
 {{- end }}
+
+{{/*
+Resolve a value-or-secret field.
+Accepts a value that is either a plain string or a map with a `secretKeyRef` key.
+Usage: {{ include "grader-service.envVar" (dict "name" "GRADER_DB_URL" "val" .Values.db.url) }}
+*/}}
+{{- define "grader-service.envVar" -}}
+- name: {{ .name }}
+{{- if eq (kindOf .val) "map" }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ .val.secretKeyRef.name }}
+      key: {{ .val.secretKeyRef.key }}
+{{- else }}
+  value: {{ .val | quote }}
+{{- end }}
+{{- end }}
+
+{{/*
+Database environment variable.
+Injects GRADER_DB_URL from a plain value or a secretKeyRef.
+This is used by all containers that need database access (main, worker, db-migration).
+*/}}
+{{- define "grader-service.dbEnv" -}}
+{{ include "grader-service.envVar" (dict "name" "GRADER_DB_URL" "val" .Values.db.url) }}
+{{- end }}
+
+{{/*
+LTI private key environment variable.
+Only rendered when LTI is enabled.
+If the value is a secretKeyRef map it is injected as an env var;
+otherwise it is written into the config file directly and no env var is needed.
+*/}}
+{{- define "grader-service.ltiEnv" -}}
+{{- if and .Values.ltiSyncGrades.enabled (eq (kindOf .Values.ltiSyncGrades.token_private_key) "map") }}
+{{ include "grader-service.envVar" (dict "name" "LTI_PRIVATE_KEY" "val" .Values.ltiSyncGrades.token_private_key) }}
+{{- end }}
+{{- end }}
+
+{{/*
+RabbitMQ credential environment variables.
+*/}}
+{{- define "grader-service.rabbitmqEnv" -}}
+- name: RABBITMQ_GRADER_SERVICE_USERNAME
+  valueFrom:
+    secretKeyRef:
+      key: username
+      name: rabbitmq-grader-service-default-user
+- name: RABBITMQ_GRADER_SERVICE_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      key: password
+      name: rabbitmq-grader-service-default-user
+{{- end }}
+
+{{/*
+Extra environment variables (supports value, valueFrom, and legacy secretKeyRef).
+*/}}
+{{- define "grader-service.extraEnv" -}}
+{{- range . }}
+- name: {{ .name }}
+{{- if .value }}
+  value: {{ .value | quote }}
+{{- else if .valueFrom }}
+  valueFrom:
+    {{- toYaml .valueFrom | nindent 4 }}
+{{- else if .secretKeyRef }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ .secretKeyRef.name }}
+      key: {{ .secretKeyRef.key }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+envFrom block for mounting entire Secrets/ConfigMaps as env vars.
+Usage: {{ include "grader-service.envFrom" (list .Values.extraEnvFrom .Values.workers.extraEnvFrom) }}
+*/}}
+{{- define "grader-service.envFrom" -}}
+{{- $sources := list }}
+{{- range . }}
+  {{- if . }}
+    {{- $sources = concat $sources . }}
+  {{- end }}
+{{- end }}
+{{- if $sources }}
+envFrom:
+  {{- toYaml $sources | nindent 2 }}
+{{- end }}
+{{- end }}

--- a/charts/grader-service/templates/celery-worker-deployment.yaml
+++ b/charts/grader-service/templates/celery-worker-deployment.yaml
@@ -12,13 +12,24 @@ spec:
       {{- include "grader-service.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
+      {{- if or .Values.podAnnotations .Values.workers.podAnnotations }}
       annotations:
+        {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.workers.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- end }}
       labels:
         {{- include "grader-service.selectorLabels" . | nindent 8 }}
         hub.jupyter.org/network-access-hub: "true"
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.workers.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -26,11 +37,19 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "grader-service.serviceAccountName" . }}
       securityContext:
+        {{- if .Values.workers.podSecurityContext }}
+        {{- toYaml .Values.workers.podSecurityContext | nindent 8 }}
+        {{- else }}
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+        {{- end }}
       containers:
         - name: {{ .Chart.Name }}-worker
           securityContext:
+            {{- if .Values.workers.securityContext }}
+            {{- toYaml .Values.workers.securityContext | nindent 12 }}
+            {{- else }}
             {{- toYaml .Values.securityContext | nindent 12 }}
+            {{- end }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: [ "grader-worker" ]
@@ -38,29 +57,18 @@ spec:
           resources:
             {{- toYaml .Values.workers.resources | nindent 12 }}
           env:
-            {{- range .Values.extraEnv }}
-            - name: {{ .name }}
-              {{- if .value }}
-              value: {{ .value }}
-              {{- else if .secretKeyRef }}
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .secretKeyRef.name }}
-                  key: {{ .secretKeyRef.key }}
-              {{- end }}
-            {{- end }}
+            {{- include "grader-service.extraEnv" .Values.extraEnv | nindent 12 }}
+            {{- include "grader-service.extraEnv" .Values.workers.extraEnv | nindent 12 }}
+            {{- include "grader-service.dbEnv" . | nindent 12 }}
+            {{- include "grader-service.ltiEnv" . | nindent 12 }}
+            {{- include "grader-service.rabbitmqEnv" . | nindent 12 }}
             - name: GRADER_PORT
               value: {{ .Values.port | quote }}
-            - name: RABBITMQ_GRADER_SERVICE_USERNAME
-              valueFrom:
-                secretKeyRef:
-                  key: username
-                  name: rabbitmq-grader-service-default-user
-            - name: RABBITMQ_GRADER_SERVICE_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  key: password
-                  name: rabbitmq-grader-service-default-user
+          {{- $envFrom := concat (.Values.extraEnvFrom | default list) (.Values.workers.extraEnvFrom | default list) }}
+          {{- with $envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: data
               mountPath: /var/lib/grader-service
@@ -88,3 +96,16 @@ spec:
           configMap:
             defaultMode: 444
             name: grader-service
+
+      {{- with (.Values.workers.nodeSelector | default .Values.nodeSelector) }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with (.Values.workers.affinity | default .Values.affinity) }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with (.Values.workers.tolerations | default .Values.tolerations) }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/grader-service/templates/configmap.yaml
+++ b/charts/grader-service/templates/configmap.yaml
@@ -8,6 +8,8 @@ metadata:
 data:
   grader_service_config.py: |
     # Grader Service Config
+    import os
+
     ### Log Level
     c.GraderService.log_level = "{{ .Values.logLevel }}"
 
@@ -37,12 +39,15 @@ data:
 {{- end }}
 
     ### Database
-    c.GraderService.db_url = "{{ .Values.db.url }}"
+{{- if eq (kindOf .Values.db.url) "map" }}
+    c.GraderService.db_url = os.environ.get("GRADER_DB_URL", "")
+{{- else }}
+    c.GraderService.db_url = os.environ.get("GRADER_DB_URL", {{ .Values.db.url | quote }})
+{{- end }}
     c.GraderService.max_buffer_size = {{ .Values.requestHandlerConfig.max_buffer_size | int }}
     c.GraderService.max_body_size = {{ .Values.requestHandlerConfig.max_body_size | int }}
 
     ### RabbitMQ
-    import os
     broker_url=f'amqp://{os.getenv("RABBITMQ_GRADER_SERVICE_USERNAME")}:{os.getenv("RABBITMQ_GRADER_SERVICE_PASSWORD")}@rabbitmq-grader-service.{{.Release.Namespace}}.svc.cluster.local'
     c.CeleryApp.conf = dict(
         broker_url=broker_url,
@@ -60,7 +65,11 @@ data:
 {{- end }}
     c.LTISyncGrades.token_url = {{ .Values.ltiSyncGrades.token_url | quote }}
     c.LTISyncGrades.client_id = {{ .Values.ltiSyncGrades.client_id | quote }}
+{{- if eq (kindOf .Values.ltiSyncGrades.token_private_key) "map" }}
+    c.LTISyncGrades.token_private_key = os.environ.get("LTI_PRIVATE_KEY", "")
+{{- else }}
     c.LTISyncGrades.token_private_key = {{ .Values.ltiSyncGrades.token_private_key | quote }}
+{{- end }}
 {{- end }}
 
 {{- if .Values.extraConfig }}

--- a/charts/grader-service/templates/deployment.yaml
+++ b/charts/grader-service/templates/deployment.yaml
@@ -18,6 +18,9 @@ spec:
       labels:
         {{- include "grader-service.selectorLabels" . | nindent 8 }}
         hub.jupyter.org/network-access-hub: "true"
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -40,18 +43,10 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           env:
-          # Include extra environment variables if they exist
-            {{- range .Values.extraEnv }}
-            - name: {{ .name }}
-              {{- if .value }}
-              value: {{ .value }}
-              {{- else if .secretKeyRef }}
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .secretKeyRef.name }}
-                  key: {{ .secretKeyRef.key }}
-              {{- end }}
-            {{- end }}
+            {{- include "grader-service.extraEnv" .Values.extraEnv | nindent 12 }}
+            {{- include "grader-service.dbEnv" . | nindent 12 }}
+            {{- include "grader-service.ltiEnv" . | nindent 12 }}
+            {{- include "grader-service.rabbitmqEnv" . | nindent 12 }}
             - name: JUPYTERHUB_API_URL
               value: {{ .Values.jupyterhub.apiUrl }}
             - name: GRADER_PORT
@@ -64,18 +59,10 @@ spec:
               value: {{ .Values.db.dialect }}
             - name: GRADER_DB_HOST
               value: {{ .Values.db.host }}
-            - name: GRADER_DB_URL
-              value: {{ .Values.db.url }}
-            - name: RABBITMQ_GRADER_SERVICE_USERNAME
-              valueFrom:
-                secretKeyRef:
-                  key: username
-                  name: rabbitmq-grader-service-default-user
-            - name: RABBITMQ_GRADER_SERVICE_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  key: password
-                  name: rabbitmq-grader-service-default-user
+          {{- with .Values.extraEnvFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: data
               mountPath: /var/lib/grader-service
@@ -90,7 +77,7 @@ spec:
               subPath: .gitconfig
   
       initContainers:
-{{ if .Values.volumePermissions.enabled }}
+{{- if .Values.volumePermissions.enabled }}
         - name: volume-permissions
           image: busybox
           command: ["/bin/sh","-c"]
@@ -101,12 +88,19 @@ spec:
 {{- if .Values.subPath }}
               subPath: {{ .Values.subPath }}
 {{- end }}
-{{ end }}
+{{- end }}
 
         - name: db-migration
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           command: ["grader-service-migrate", "-f", "/etc/grader-service/grader_service_config.py"]
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            {{- include "grader-service.extraEnv" .Values.extraEnv | nindent 12 }}
+            {{- include "grader-service.dbEnv" . | nindent 12 }}
+          {{- with .Values.extraEnvFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: config
               mountPath: /etc/grader-service/grader_service_config.py
@@ -132,7 +126,6 @@ spec:
           configMap:
             defaultMode: 444
             name: grader-service
-
 
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/grader-service/values.yaml
+++ b/charts/grader-service/values.yaml
@@ -2,27 +2,46 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+# -- Container image configuration
 image:
+  # -- Image repository
   repository: ghcr.io/tu-wien-datalab/grader-service
+  # -- Image pull policy
   pullPolicy: IfNotPresent
-  # Overrides the image tag whose default is the chart appVersion.
-  #tag: "latest"
+  # -- Overrides the image tag whose default is the chart appVersion
+  # tag: "latest"
 
+# -- Image pull secrets for private registries
 imagePullSecrets: []
+# -- Override the name of the chart
 nameOverride: ""
+# -- Override the full name of the chart
 fullnameOverride: "grader-service"
 
+# -- Service account configuration
 serviceAccount:
-  # Specifies whether a service account should be created or not
+  # -- Specifies whether a service account should be created
   create: true
-  # Annotations to add to the service account
+  # -- Annotations to add to the service account
   annotations: {}
 
+# ---------------------------------------------------------------------------
+# Pod configuration (shared defaults for all deployments)
+# These values apply to both the main deployment and the worker deployment
+# unless overridden in the `workers` section.
+# ---------------------------------------------------------------------------
+
+# -- Annotations to add to all pods (main + worker)
 podAnnotations: {}
 
+# -- Extra labels to add to all pods (main + worker)
+podLabels: {}
+
+# -- Pod-level security context (shared)
 podSecurityContext: {}
   # fsGroup: 2000
 
+# -- Container-level security context (shared)
 securityContext: {}
   # capabilities:
   #   drop:
@@ -31,101 +50,281 @@ securityContext: {}
   # runAsNonRoot: true
   # runAsUser: 1000
 
+# ---------------------------------------------------------------------------
+# Environment variables
+# ---------------------------------------------------------------------------
+
+# -- Extra environment variables injected into all containers (main, worker, init).
+# Supports both simple values and Kubernetes-native valueFrom references.
+# @default -- `[]`
+# Example:
+#   extraEnv:
+#     - name: MY_VAR
+#       value: "my-value"
+#     - name: MY_SECRET_VAR
+#       valueFrom:
+#         secretKeyRef:
+#           name: my-secret
+#           key: my-key
+#     # Legacy format (still supported):
+#     - name: LEGACY_SECRET
+#       secretKeyRef:
+#         name: my-secret
+#         key: my-key
 extraEnv: []
 
+# -- Mount entire Secrets or ConfigMaps as environment variables in all containers.
+# @default -- `[]`
+# Example:
+#   extraEnvFrom:
+#     - secretRef:
+#         name: my-secret
+#     - configMapRef:
+#         name: my-configmap
+extraEnvFrom: []
+
+# ---------------------------------------------------------------------------
+# Service configuration
+# ---------------------------------------------------------------------------
+
+# -- Kubernetes service configuration
 service:
+  # -- Service type
   type: ClusterIP
+  # -- Service port
   port: 4010
+
+# -- Container port for the grader service
 port: 4010
 
+# ---------------------------------------------------------------------------
+# JupyterHub integration
+# ---------------------------------------------------------------------------
+
 jupyterhub:
+  # -- JupyterHub API URL
   apiUrl: http://hub:8081/hub/api
+  # -- JupyterHub base URL path
   baseUrl: /
+  # -- JupyterHub API token (stored in the grader-service Secret)
+  # apiToken: ""
+
+# ---------------------------------------------------------------------------
+# Database configuration
+# ---------------------------------------------------------------------------
 
 db:
+  # -- Database dialect (e.g. sqlite, postgresql)
   dialect: sqlite
+  # -- Database host (used as env var GRADER_DB_HOST)
   host: /var/lib/grader-service/grader.db
+  # -- Full database URL. Accepts either a plain string value or a
+  # secretKeyRef map to source the URL from a Kubernetes Secret.
+  # Only one format may be used — do not set both.
+  #
+  # Plain string (default):
+  #   url: "sqlite:///grader.db"
+  #
+  # From a Kubernetes Secret:
+  #   url:
+  #     secretKeyRef:
+  #       name: grader-db-credentials
+  #       key: url
   url: "sqlite:///grader.db"
 
+# ---------------------------------------------------------------------------
+# Git configuration
+# ---------------------------------------------------------------------------
+
 gitConfig:
+  # -- Git user name used for commits
   gitUser: "grader-service"
+  # -- Git user email used for commits
   gitEmail: "grader-service@mail.com"
 
+# ---------------------------------------------------------------------------
+# Volume permissions init container
+# ---------------------------------------------------------------------------
+
 volumePermissions:
+  # -- Enable init container that fixes volume ownership
   enabled: true
 
+# ---------------------------------------------------------------------------
+# Autograding configuration
+# ---------------------------------------------------------------------------
+
+# -- Autograde executor class. Set to "KubeAutogradeExecutor" for Kubernetes
+# or "LocalAutogradeExecutor" for local execution.
 autogradeExecutorClass: KubeAutogradeExecutor
+
+# -- Configuration for the Kubernetes autograde executor
 kubeAutogradeExecutor:
+  # -- Annotations for autograde pods
   annotations: {}
+  # -- Image to use for autograde pods
   image: ghcr.io/tu-wien-datalab/grader-service-labextension
+  # -- Image tag for autograde pods
   tag: latest
+  # -- Image pull policy for autograde pods
   imagePullPolicy: "Always"
+  # -- Image pull secrets for autograde pods
   imagePullSecrets: []
+  # -- Labels for autograde pods
   labels: {}
+  # -- Namespace for autograde pods (defaults to release namespace)
   namespace: null
+  # -- Extra volumes for autograde pods (Python list literal as string)
   extraVolumes: ""
+  # -- Extra volume mounts for autograde pods (Python list literal as string)
   extraVolumeMounts: ""
 
+# -- Extra Python configuration appended to grader_service_config.py
 extraConfig: ""
 
+# -- Request handler configuration
 requestHandlerConfig:
+  # -- Max git file size in MB
   git_max_file_size_mb: 500
+  # -- Max buffer size in bytes (default 100MB)
   max_buffer_size: 104857600
+  # -- Max body size in bytes (default 100MB)
   max_body_size: 104857600
 
-# lti
+# ---------------------------------------------------------------------------
+# LTI Grade Sync plugin
+# ---------------------------------------------------------------------------
+
 ltiSyncGrades:
+  # -- Enable LTI grade synchronization
   enabled: false
+  # -- Automatically sync grades when feedback is generated
   sync_on_feedback: false
+  # -- LTI OAuth2 client ID
   client_id: ""
+  # -- LTI OAuth2 token endpoint URL
   token_url: ""
+  # -- Private key for signing LTI token requests (PEM format).
+  # Accepts either a plain string value or a secretKeyRef map to source
+  # the key from a Kubernetes Secret. Only one format may be used.
+  #
+  # Plain string:
+  #   token_private_key: |
+  #     -----BEGIN RSA PRIVATE KEY-----
+  #     ...
+  #     -----END RSA PRIVATE KEY-----
+  #
+  # From a Kubernetes Secret:
+  #   token_private_key:
+  #     secretKeyRef:
+  #       name: lti-credentials
+  #       key: private_key
   token_private_key: ""
 
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+
+# -- Log level for the grader service
 logLevel: "INFO"
 
+# ---------------------------------------------------------------------------
+# Storage / PVC configuration
+# ---------------------------------------------------------------------------
 
-# pvc
+# -- Storage class name for the PVC (empty = cluster default)
 storageClassName: ""
+# -- Access mode for the PVC
 accessMode: "ReadWriteMany"
+# -- Storage capacity for the PVC
 capacity: "10G"
+# -- Existing PersistentVolume name to bind to
 volume: ""
+# -- Use a hostPath volume instead of a PVC
 hostpath: ""
+# -- SubPath within the volume to mount
+subPath: ""
+
+# ---------------------------------------------------------------------------
+# Ingress
+# ---------------------------------------------------------------------------
 
 ingress:
+  # -- Enable ingress
   enabled: false
+  # -- Ingress class name
   className: ""
+  # -- Ingress annotations
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
+  # -- Ingress host rules
   hosts:
     - host: chart-example.local
       paths:
         - path: /
           pathType: ImplementationSpecific
+  # -- Ingress TLS configuration
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:
   #      - chart-example.local
 
+# ---------------------------------------------------------------------------
+# RabbitMQ
+# ---------------------------------------------------------------------------
+
 rabbitmq:
+  # -- Resource requests and limits for the RabbitMQ cluster
   resources:
-      requests:
-        cpu: 2
-        memory: 4Gi
-      limits:
-        cpu: 2
-        memory: 4Gi
+    requests:
+      cpu: 2
+      memory: 4Gi
+    limits:
+      cpu: 2
+      memory: 4Gi
+  # -- Override spec for the RabbitmqCluster CR
   override: {}
 
+# ---------------------------------------------------------------------------
+# Celery workers
+# ---------------------------------------------------------------------------
+
 workers:
+  # -- Number of worker replicas
   replication: 1
+  # -- Resource requests and limits for worker containers
   resources: {}
 
+  # Per-deployment overrides (if not set, inherits from global values above)
+
+  # -- Extra labels for worker pods only
+  podLabels: {}
+  # -- Annotations for worker pods only
+  podAnnotations: {}
+  # -- Pod-level security context for workers
+  podSecurityContext: {}
+  # -- Container-level security context for workers
+  securityContext: {}
+  # -- Node selector for worker pods
+  nodeSelector: {}
+  # -- Tolerations for worker pods
+  tolerations: []
+  # -- Affinity rules for worker pods
+  affinity: {}
+  # -- Extra environment variables for worker containers only
+  # (these are added on top of the global `extraEnv`)
+  extraEnv: []
+  # -- Extra envFrom sources for worker containers only
+  # (these are added on top of the global `extraEnvFrom`)
+  extraEnvFrom: []
+
+# ---------------------------------------------------------------------------
+# Main deployment scheduling
+# ---------------------------------------------------------------------------
+
+# -- Resource requests and limits for the main grader-service container
 resources: {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
   # limits:
   #   cpu: 100m
   #   memory: 128Mi
@@ -133,9 +332,11 @@ resources: {}
   #   cpu: 100m
   #   memory: 128Mi
 
+# -- Node selector for main deployment pods
 nodeSelector: {}
 
+# -- Tolerations for main deployment pods
 tolerations: []
 
+# -- Affinity rules for main deployment pods
 affinity: {}
-


### PR DESCRIPTION
# New features
## Unified Value-or-Secret Pattern

Sensitive configuration values now use a single field that accepts **either** a plain string **or** a `secretKeyRef` map. This prevents double-allocation and keeps the values file clean.

### Example: Database URL

**Plain string (default):**
```yaml
db:
  url: "postgresql://user:pass@host:5432/grader"
```

**From a Kubernetes Secret:**
```yaml
db:
  url:
    secretKeyRef:
      name: grader-db-credentials
      key: url
```
##  Quote function
Env var values set via `extraEnv` are now passed through Helm's `quote` function for safer YAML rendering. Since Kubernetes environment variable values are always strings.

## Pod Labels

Add custom labels to all pods:

```yaml
podLabels:
  team: my-team
  environment: production
```

Worker-specific labels (merged with global):

```yaml
workers:
  podLabels:
    component: worker
```