### PR TITLE
fix: allow all users to access `/config` endpoint

### DIFF
--- a/grader_service/handlers/base_handler.py
+++ b/grader_service/handlers/base_handler.py
@@ -85,6 +85,7 @@ def check_authorization(
             "/permissions" in request_path
             or "/lectures" in request_path
             or "/health" in request_path
+            or "/config" in request_path
         ):
             # all users are allowed to access these endpoints
             return True
@@ -811,7 +812,7 @@ class GraderErrorMixin:
 
             self.finish(json.dumps(reply))
         else:
-            super().write_error(status_code, exc_info=exc)
+            super().write_error(status_code, **kwargs)
 
 
 class GraderBaseHandler(GraderErrorMixin, BaseHandler):

--- a/grader_service/handlers/config.py
+++ b/grader_service/handlers/config.py
@@ -1,7 +1,8 @@
 import traitlets.config
 
 from grader_service.autograding.local_grader import LocalAutogradeExecutor
-from grader_service.handlers.base_handler import GraderBaseHandler
+from grader_service.handlers.base_handler import GraderBaseHandler, authorize
+from grader_service.orm.takepart import Scope
 from grader_service.registry import VersionSpecifier, register_handler
 
 
@@ -30,6 +31,7 @@ class ConfigHandler(GraderBaseHandler):
     Handler class for requests to /config
     """
 
+    @authorize([Scope.student, Scope.tutor, Scope.instructor, Scope.admin])
     async def get(self):
         app_cfg = self.application.config
         executor_class = app_cfg.RequestHandlerConfig.autograde_executor_class

--- a/grader_service/handlers/config.py
+++ b/grader_service/handlers/config.py
@@ -1,8 +1,7 @@
 import traitlets.config
 
 from grader_service.autograding.local_grader import LocalAutogradeExecutor
-from grader_service.handlers.base_handler import GraderBaseHandler, authorize
-from grader_service.orm.takepart import Scope
+from grader_service.handlers.base_handler import GraderBaseHandler
 from grader_service.registry import VersionSpecifier, register_handler
 
 
@@ -31,7 +30,6 @@ class ConfigHandler(GraderBaseHandler):
     Handler class for requests to /config
     """
 
-    @authorize([Scope.tutor, Scope.instructor])
     async def get(self):
         app_cfg = self.application.config
         executor_class = app_cfg.RequestHandlerConfig.autograde_executor_class

--- a/grader_service/tests/handlers/test_config_handler.py
+++ b/grader_service/tests/handlers/test_config_handler.py
@@ -17,7 +17,7 @@ from grader_service.server import GraderServer
 class TestConfigHandler:
     """Tests for the ConfigHandler endpoint."""
 
-    @pytest.fixture(autouse=True)
+    @pytest.fixture(autouse=False)
     def ensure_app_config(self, app):
         # minimal fixture to ensure app.config and required fields are set for the handler logic
         app.application = app
@@ -68,7 +68,6 @@ class TestConfigHandler:
         default_token,
         default_roles,
         default_user_login,
-        ensure_app_config,
     ):
         """Test retrieval of custom cell timeout values when set in config."""
         # Create custom config
@@ -139,6 +138,7 @@ class TestConfigHandler:
         default_token,
         default_roles,
         default_user_login,
+        ensure_app_config,
     ):
         """Test that config response has the expected structure."""
         url = service_base_url + "config"

--- a/grader_service/tests/handlers/test_config_handler.py
+++ b/grader_service/tests/handlers/test_config_handler.py
@@ -1,0 +1,157 @@
+# Copyright (c) 2026, TU Wien
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import json
+import pathlib
+from http import HTTPStatus
+
+import pytest
+from traitlets.config import Config
+
+from grader_service.server import GraderServer
+
+
+class TestConfigHandler:
+    """Tests for the ConfigHandler endpoint."""
+
+    @pytest.fixture(autouse=True)
+    def ensure_app_config(self, app):
+        # minimal fixture to ensure app.config and required fields are set for the handler logic
+        app.application = app
+        # Ensure the required executor class is set for the handler logic
+        if not hasattr(app.config, "RequestHandlerConfig"):
+            app.config.RequestHandlerConfig = Config()
+        if app.config.RequestHandlerConfig.get("autograde_executor_class") is None:
+            from grader_service.autograding.local_grader import LocalAutogradeExecutor
+
+            app.config.RequestHandlerConfig.autograde_executor_class = LocalAutogradeExecutor
+
+    def load_fake_config(self, path):
+        c = Config()
+        with open(path, "r") as f:
+            code = f.read()
+        exec(code, {"c": c})
+        return c
+
+    async def test_get_default_cell_timeout_values(
+        self,
+        app: GraderServer,
+        service_base_url,
+        http_server_client,
+        default_token,
+        default_roles,
+        default_user_login,
+        ensure_app_config,
+    ):
+        """Test retrieval of default cell timeout values when no custom config is set."""
+        url = service_base_url + "config"
+
+        response = await http_server_client.fetch(
+            url, method="GET", headers={"Authorization": f"Token {default_token}"}
+        )
+        assert response.code == HTTPStatus.OK
+        config_data = json.loads(response.body.decode())
+
+        # Verify default values from LocalAutogradeExecutor
+        assert config_data["default_cell_timeout"] == 300
+        assert config_data["min_cell_timeout"] == 10
+        assert config_data["max_cell_timeout"] == 86400
+
+    async def test_get_custom_cell_timeout_values(
+        self,
+        app: GraderServer,
+        service_base_url,
+        http_server_client,
+        default_token,
+        default_roles,
+        default_user_login,
+        ensure_app_config,
+    ):
+        """Test retrieval of custom cell timeout values when set in config."""
+        # Create custom config
+        fake_config_path = (
+            pathlib.Path(__file__).parent / "test_files" / "fake_grader_service_config.py"
+        )
+        fake_config = self.load_fake_config(fake_config_path)
+        app.config = fake_config
+
+        url = service_base_url + "config"
+
+        response = await http_server_client.fetch(
+            url, method="GET", headers={"Authorization": f"Token {default_token}"}
+        )
+        assert response.code == HTTPStatus.OK
+        config_data = json.loads(response.body.decode())
+
+        # Verify custom values
+        assert config_data["default_cell_timeout"] == 200
+        assert config_data["min_cell_timeout"] == 20
+        assert config_data["max_cell_timeout"] == 3600
+
+    async def test_get_partial_custom_cell_timeout_values(
+        self,
+        app: GraderServer,
+        service_base_url,
+        http_server_client,
+        default_token,
+        default_roles,
+        default_user_login,
+        ensure_app_config,
+    ):
+        """Test retrieval when only some timeout values are customized in config."""
+        # Create custom config with only some values set
+
+        custom_config = Config()
+        custom_config.LocalAutogradeExecutor.default_cell_timeout = 150
+        app.config.merge(custom_config)
+
+        url = service_base_url + "config"
+
+        response = await http_server_client.fetch(
+            url, method="GET", headers={"Authorization": f"Token {default_token}"}
+        )
+        assert response.code == HTTPStatus.OK
+        config_data = json.loads(response.body.decode())
+
+        # Verify the custom value and defaults for others
+        assert config_data["default_cell_timeout"] == 150
+        assert config_data["min_cell_timeout"] == 10  # default
+        assert config_data["max_cell_timeout"] == 86400  # default
+
+    async def test_config_endpoint_requires_authorization(
+        self, app: GraderServer, service_base_url, http_server_client
+    ):
+        """Test that config endpoint requires proper authorization."""
+        url = service_base_url + "config"
+
+        # Try without token - should fail
+        with pytest.raises(Exception):  # HTTPClientError or similar
+            await http_server_client.fetch(url, method="GET")
+
+    async def test_get_config_response_structure(
+        self,
+        app: GraderServer,
+        service_base_url,
+        http_server_client,
+        default_token,
+        default_roles,
+        default_user_login,
+    ):
+        """Test that config response has the expected structure."""
+        url = service_base_url + "config"
+
+        response = await http_server_client.fetch(
+            url, method="GET", headers={"Authorization": f"Token {default_token}"}
+        )
+        assert response.code == HTTPStatus.OK
+        config_data = json.loads(response.body.decode())
+
+        # Verify all expected keys are present
+        expected_keys = {"default_cell_timeout", "min_cell_timeout", "max_cell_timeout"}
+        assert set(config_data.keys()) == expected_keys
+
+        # Verify values are integers
+        assert all(isinstance(config_data[key], int) for key in expected_keys)

--- a/grader_service/tests/handlers/test_files/fake_grader_service_config.py
+++ b/grader_service/tests/handlers/test_files/fake_grader_service_config.py
@@ -1,14 +1,11 @@
+# ruff: noqa: F821
 """
 Fake grader service configuration file for testing the config endpoint.
 This file can be used to test the retrieval of cell timeout configurations
 when different timeout values are configured.
 """
 
-from traitlets.config import Config
-
 from grader_service.autograding.local_grader import LocalAutogradeExecutor
-
-c = Config()
 
 # Test configuration with custom cell timeout values
 c.RequestHandlerConfig.autograde_executor_class = LocalAutogradeExecutor

--- a/grader_service/tests/handlers/test_files/fake_grader_service_config.py
+++ b/grader_service/tests/handlers/test_files/fake_grader_service_config.py
@@ -1,0 +1,19 @@
+"""
+Fake grader service configuration file for testing the config endpoint.
+This file can be used to test the retrieval of cell timeout configurations
+when different timeout values are configured.
+"""
+
+from traitlets.config import Config
+
+from grader_service.autograding.local_grader import LocalAutogradeExecutor
+
+c = Config()
+
+# Test configuration with custom cell timeout values
+c.RequestHandlerConfig.autograde_executor_class = LocalAutogradeExecutor
+
+# Custom timeout values that differ from defaults
+c.LocalAutogradeExecutor.default_cell_timeout = 200
+c.LocalAutogradeExecutor.min_cell_timeout = 20
+c.LocalAutogradeExecutor.max_cell_timeout = 3600


### PR DESCRIPTION
This fix allows all users to access this endpoint. Again, this solution is only temporary, probably the best we can do currently. 