### PR TITLE
fix: generate feedback when autograding has failed

### DIFF
--- a/grader_service/autograding/local_feedback.py
+++ b/grader_service/autograding/local_feedback.py
@@ -29,7 +29,10 @@ class FeedbackGitSubmissionManager(GitSubmissionManager):
         # pull from user repo to generate feedback
         if (
             assignment.settings.autograde_type == "unassisted"
-            and submission.auto_status == AutoStatus.NOT_GRADED
+            and (
+                submission.auto_status == AutoStatus.NOT_GRADED
+                or submission.auto_status == AutoStatus.GRADING_FAILED
+            )
             and submission.manual_status == ManualStatus.MANUALLY_GRADED
         ):
             self.input_repo_type = GitRepoType.USER

--- a/grader_service/autograding/local_feedback.py
+++ b/grader_service/autograding/local_feedback.py
@@ -24,17 +24,12 @@ class FeedbackGitSubmissionManager(GitSubmissionManager):
 
     def __init__(self, grader_service_dir: str, submission: Submission, **kwargs: Any):
         super().__init__(grader_service_dir, submission, **kwargs)
-        assignment = submission.assignment
-        # When autograding is unassisted and submission hasn't been autograded,
+        # When submission hasn't been autograded or autograding failed,
         # pull from user repo to generate feedback
         if (
-            assignment.settings.autograde_type == "unassisted"
-            and (
-                submission.auto_status == AutoStatus.NOT_GRADED
-                or submission.auto_status == AutoStatus.GRADING_FAILED
-            )
-            and submission.manual_status == ManualStatus.MANUALLY_GRADED
-        ):
+            submission.auto_status == AutoStatus.NOT_GRADED
+            or submission.auto_status == AutoStatus.GRADING_FAILED
+        ) and submission.manual_status == ManualStatus.MANUALLY_GRADED:
             self.input_repo_type = GitRepoType.USER
         else:
             self.input_branch = f"submission_{self.submission.commit_hash}"


### PR DESCRIPTION
We want to allow instructors to manually grade a submission and generate feedback even if autograding fails, regardless of autograding behavior.