### PR TITLE
fix(service): ship grader_service.api.models and other subpackages in wheel

### DIFF
--- a/packages/service/CHANGELOG.md
+++ b/packages/service/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.5] - 2026-07-15
+
+### Fixed
+- The 0.12.4 wheel omitted `grader_service.api.models` and eight other runtime subpackages (`autograding.kube`, `convert.converters`, `convert.gradebook`, `convert.nbgraderformat`, `convert.preprocessors`, `handlers.git`, `migrate.versions`, `scripts`), causing the `db-migration` init container to fail with `ModuleNotFoundError: No module named 'grader_service.api.models'`; restored setuptools auto-discovery (equivalent to the previous `find_packages`) which the `setup.py` -> `pyproject.toml` migration had replaced with a stale explicit package list (#381)
+
 ## [0.12.4] - 2026-07-07
 
 ### Added

--- a/packages/service/charts/grader-service-all-in-one/Chart.yaml
+++ b/packages/service/charts/grader-service-all-in-one/Chart.yaml
@@ -21,7 +21,7 @@ version: 0.12.4
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.12.4"
+appVersion: "0.12.5"
 
 dependencies:
 - name: jupyterhub

--- a/packages/service/charts/grader-service/Chart.yaml
+++ b/packages/service/charts/grader-service/Chart.yaml
@@ -21,4 +21,4 @@ version: 0.12.4
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.12.4"
+appVersion: "0.12.5"

--- a/packages/service/grader_service/_version.py
+++ b/packages/service/grader_service/_version.py
@@ -5,4 +5,4 @@
 # LICENSE file in the root directory of this source tree.
 
 # version_info updated by running `tbump`
-__version__ = "0.12.4"
+__version__ = "0.12.5"

--- a/packages/service/pyproject.toml
+++ b/packages/service/pyproject.toml
@@ -47,7 +47,11 @@ dependencies = [
 
 [tool.setuptools]
 include-package-data = true
-packages = ["grader_service", "grader_service.api", "grader_service.auth", "grader_service.auth.lti13", "grader_service.autograding", "grader_service.autograding.celery", "grader_service.convert", "grader_service.handlers", "grader_service.migrate", "grader_service.oauth2", "grader_service.orm", "grader_service.plugins"]
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["grader_service*"]
+exclude = ["grader_service.tests*"]
 
 [project.scripts]
 grader-service = "grader_service:main"

--- a/packages/service/pyproject.toml
+++ b/packages/service/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "grader-service"
 description = "Grader service"
-version = "0.12.4"
+version = "0.12.5"
 requires-python = ">=3.9"
 authors = [{name='Florian Jäger'}, {name='Matthias Matt'}]
 license = "BSD-3-Clause"
@@ -69,7 +69,7 @@ Documentation = "https://grader-service.readthedocs.io/en/latest/index.html"
 github_url = "https://github.com/TU-Wien-dataLAB/grader-service"
 
 [tool.tbump.version]
-current = "0.12.4"
+current = "0.12.5"
 
 # Example of a semver regexp.
 # Make sure this matches current_version before

--- a/uv.lock
+++ b/uv.lock
@@ -1997,7 +1997,7 @@ docs = [
 
 [[package]]
 name = "grader-service"
-version = "0.12.4"
+version = "0.12.5"
 source = { editable = "packages/service" }
 dependencies = [
     { name = "alembic", version = "1.16.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },


### PR DESCRIPTION
## Problem

The `db-migration` init container fails in chart 0.12.4 with:

```
ModuleNotFoundError: No module named 'grader_service.api.models'
```

## Root cause

The 0.12.4 release migrated packaging from `setup.py` (`find_packages(...)`, auto-discovery) to `pyproject.toml` with a hand-maintained explicit `packages` list. That list included `grader_service.api` but omitted `grader_service.api.models`, so setuptools dropped the entire `api/models/` directory from the built wheel.

`grader-service-migrate` imports `grader_service.migrate.migrate`, and `grader_service/__init__.py` chains into `main` -> `auth` -> `handlers/__init__` -> `assignment.py` -> `from grader_service.api.models.assignment import ...`, which is absent from the installed wheel.

## Scope

Wider than the reported error. Comparing on-disk packages against the explicit list, **nine** runtime subpackages were missing from the wheel:

- `grader_service.api.models` (the one triggering the migration error)
- `grader_service.autograding.kube`
- `grader_service.convert.converters`
- `grader_service.convert.gradebook`
- `grader_service.convert.nbgraderformat`
- `grader_service.convert.preprocessors`
- `grader_service.handlers.git`
- `grader_service.migrate.versions`
- `grader_service.scripts`

## Fix

Replace the stale explicit `packages` list with setuptools auto-discovery, restoring the original `find_packages` behaviour:

```toml
[tool.setuptools.packages.find]
where = ["."]
include = ["grader_service*"]
exclude = ["grader_service.tests*"]
```

## Verification

Built the wheel (`uv build --wheel`) and confirmed:
- All 15 `grader_service/api/models/*.py` files now present (incl. `assignment.py` from the traceback)
- All 9 previously-missing subpackages now included
- `grader_service/tests/` correctly excluded (0 files)

Auto-discovery won't go stale when subpackages are added; all intended subpackages have an `__init__.py` (verified).

Refs: #380 